### PR TITLE
Use the symbol at point as the default query value for lookup.

### DIFF
--- a/javadoc-lookup.el
+++ b/javadoc-lookup.el
@@ -183,7 +183,7 @@ always be there."
     (ignore-errors ; Provide *something* useful, if needed
       (jdl/web "http://docs.oracle.com/javase/7/docs/api/")))
   (funcall javadoc-lookup-completing-read-function "Class: "
-           (jdl/get-class-list) nil nil (thing-at-point 'symbol)))
+           (jdl/get-class-list) nil nil (cons (thing-at-point 'symbol) 0)))
 
 ;;;###autoload
 (defun javadoc-lookup (name)


### PR DESCRIPTION
The lookup process can be made even quicker: if the cursor is currently on top of the class name, the user doesn't have to retype it in the minibuffer.
