### PR TITLE
Set `require-final-newline` to nil temporarily.

### DIFF
--- a/javadoc-lookup.el
+++ b/javadoc-lookup.el
@@ -97,10 +97,11 @@
 
 (defun jdl/load-cache (cache-file)
   "Load a cache from disk."
-  (with-current-buffer (find-file-noselect cache-file)
-    (goto-char (point-min))
-    (jdl/add-hash (read (current-buffer)))
-    (kill-buffer)))
+  (let ((require-final-newline nil))
+    (with-current-buffer (find-file-noselect cache-file)
+      (goto-char (point-min))
+      (jdl/add-hash (read (current-buffer)))
+      (kill-buffer))))
 
 (defun jdl/save-cache (cache-file hash)
   "Save a cache to the disk."


### PR DESCRIPTION
When visiting the cache files with `require-final-newline` set to `t` or
to `visit-save`, a newline character is added at the end of the buffer,
modifying it and causing an annoying prompt for each buffer before
killing it.  Temporarily disabling it solves the problem.
